### PR TITLE
Fix debian build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include CHANGES
 include COPYING
 include LICENSE
 include INSTALL
-include README
+include README.md
 include README.translations.txt
 include Makefile.gettext
 include keepnote/images/*.png

--- a/pkg/deb/debian/docs
+++ b/pkg/deb/debian/docs
@@ -1,1 +1,1 @@
-README
+README.md

--- a/pkg/deb/debian/rules
+++ b/pkg/deb/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
-DEB_PYTHON_SYSTEM=pycentral
-#DEB_PYTHON_SYSTEM=pysupport
+#DEB_PYTHON_SYSTEM=pycentral
+DEB_PYTHON_SYSTEM=pysupport
 
 # Debhelper must be included before python-distutils to use
 # dh_python / dh_pycentral / dh_pysupport


### PR DESCRIPTION
Fixes renaming of README to README.md (#718) and addresses unavailability of python-central in Debian Jessie.
