### PR TITLE
platform-specific default behavior for external apps

### DIFF
--- a/keepnote/__init__.py
+++ b/keepnote/__init__.py
@@ -575,12 +575,23 @@ def get_external_app_defaults():
     elif get_platform() == "unix":
         return [
             ExternalApp("file_launcher", "File Launcher", u"xdg-open"),
-            ExternalApp("web_browser", "Web Browser", u""),
-            ExternalApp("file_explorer", "File Explorer", u""),
-            ExternalApp("text_editor", "Text Editor", u""),
+            ExternalApp("web_browser", "Web Browser", u"xdg-open"),
+            ExternalApp("file_explorer", "File Explorer", u"xdg-open"),
+            ExternalApp("text_editor", "Text Editor", u"xdg-open"),
             ExternalApp("image_editor", "Image Editor", u""),
             ExternalApp("image_viewer", "Image Viewer", u"display"),
             ExternalApp("screen_shot", "Screen Shot", u"import")
+        ]
+
+    elif get_platform() == "darwin":
+        return [
+            ExternalApp("file_launcher", "File Launcher", u"open"),
+            ExternalApp("web_browser", "Web Browser", u"open"),
+            ExternalApp("file_explorer", "File Explorer", u"open"),
+            ExternalApp("text_editor", "Text Editor", u"open"),
+            ExternalApp("image_editor", "Image Editor", u""),
+            ExternalApp("image_viewer", "Image Viewer", u"open"),
+            ExternalApp("screen_shot", "Screen Shot", u"")
         ]
     else:
         return DEFAULT_EXTERNAL_APPS


### PR DESCRIPTION
by default, hyperlinks, external text files, and external images will be opened with xdg-open (on linux) or open (on mac) by default. this should resolve #728. Previously, trying to open a link, image, or filethese just caused an error message if the user had not chosen an external application.

I could not test the behaviour on Mac (I don't have one) but it works on Linux. Windows should already do the right thing.

If you have an existing installation of keepnote you need to delete your config files (.config/keepnote on linux) for this to take effect.
